### PR TITLE
filenames not containing / are relative to /proc/net/xt_recent/

### DIFF
--- a/iptables_xt_recent_parser/ipt_recents
+++ b/iptables_xt_recent_parser/ipt_recents
@@ -27,7 +27,8 @@ from copy import copy
 import os
 import subprocess
 
-_fpath = '/proc/net/xt_recent/DEFAULT'
+_rpath = '/proc/net/xt_recent/'
+_fpath = _rpath + 'DEFAULT'
 _kernel_config_path = '/boot/config-' + subprocess.getoutput(['uname -r'])
 _datetime_format = '%Y-%m-%d %H:%M:%S'
 
@@ -302,6 +303,8 @@ if __name__ == '__main__':
 
     if args.f:
         _fpath = args.f
+        if '/' not in _fpath:
+            _fpath =  _rpath + _fpath
 
     print('Parsing file: {}'.format(_fpath))
     xt = XtRecentTable(fpath=_fpath)


### PR DESCRIPTION
As xt_recent files are located in `/proc/net/xt_recent/` usually I changed your script to to assume a filename no containing a slash (/) is relative to  `/proc/net/xt_recent/`.

```bash
# in /proc/net/xt_recent/ with full path
./ipt_recents -txt -f /proc/net/xt_recent/KNOCKING

# in /proc/net/xt_recent/ with file name only 
./ipt_recents -txt -f KNOCKING

# relative to local dir as before
./ipt_recents -txt -f ./KNOCKING
```